### PR TITLE
Three fixes.

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -690,6 +690,18 @@
  * SEE:      "FIXES_SetPlayerAmmo", "FIXES_GivePlayerWeapon".
  * AUTHOR:   Freaksken (https://github.com/WoutProvost)
  *
+ * FIX:      JIT
+ * PROBLEM:  Can't easily determine if the script is JIT compiled.
+ * SOLUTION: Provide "IS_JIT" to the script for tests.
+ * SEE:      "OnJITCompile".
+ * AUTHOR:   Y_Less (https://github.com/Y-Less)
+ *
+ * FIX:      OS
+ * PROBLEM:  Can't easily determine what OS the script is running on.
+ * SOLUTION: Provide "IS_WINDOWS" and "IS_LINUX" to the script for tests.
+ * SEE:      "_FIXES_DetermineOS".
+ * AUTHOR:   Y_Less (https://github.com/Y-Less)
+ *
  * ==============
  *  STYLE RULES:
  * ==============
@@ -1618,6 +1630,20 @@
 	#define FIX_GetPlayerAmmo      (2)
 #endif
 
+#if !defined FIX_JIT
+	#define FIX_JIT                      (1)
+#elseif _FIXES_IS_UNSET(FIX_JIT)
+	#undef FIX_JIT
+	#define FIX_JIT                      (2)
+#endif
+
+#if !defined FIX_OS
+	#define FIX_OS                       (1)
+#elseif _FIXES_IS_UNSET(FIX_OS)
+	#undef FIX_OS
+	#define FIX_OS                       (2)
+#endif
+
 /*
  * CHAIN_ORDER
  *
@@ -1898,7 +1924,9 @@ enum e_FIXES_SETTINGS (<<= 1)
 #define _FIXES_IS_PLAYER_CONNECTED(%0) (_FIXES_IN_RANGE((%0), 0, MAX_PLAYERS) && IsPlayerConnected((%0)))
 
 // These varaibles are NOT pre-processor dependent as they are stock.  It's just
-// simpler than trying to figure out when or if a semi-colon is needed.
+// simpler than trying to figure out when or if a semi-colon is needed.  The
+// three `_FIXES_gIs...` variables always exist, they are only `static` if the
+// relevant fixes are not enabled since they may still be needed in this file.
 #if !FIX_FILTERSCRIPT
 static
 #endif
@@ -1909,6 +1937,28 @@ stock
 	 * Runtime equivalent of "FILTERSCRIPT" for when it is not set by the user.
 	 */
 	bool:_FIXES_gIsFilterscript;
+
+#if !FIX_JIT
+static
+#endif
+stock
+	/*
+	 * bool:_FIXES_gIsJIT
+	 *
+	 * True when the JIT plugin is being used.
+	 */
+	bool:_FIXES_gIsJIT = false;
+
+#if !FIX_OS
+static
+#endif
+stock
+	/*
+	 * bool:_FIXES_gIsWindows
+	 *
+	 * True on Windows, false on Linux.
+	 */
+	bool:_FIXES_gIsWindows;
 
 stock const
 	/*
@@ -1931,6 +1981,12 @@ static stock
 	 * file in functions that don't take `const` strings.
 	 */
 	FIXES_gsSpace[] = " ",
+	/*
+	 * bool:FIXES_gsKnownOS
+	 *
+	 * Only determine the OS once.
+	 */
+	bool:FIXES_gsKnownOS = false,
 	/*
 	 * FIXES_gsPlayersIterator[MAX_PLAYERS + 1]
 	 *
@@ -2808,11 +2864,11 @@ static stock const
 	 */
 	FIXES_gscMenuProperty[] = "FIXES_gscMenuProperty",
 	/*
-	 * FIXES_gscFixesError[]
+	 * FIXES_gscMultiScriptError[]
 	 *
-	 * Error shown when multiple scripts are detected.
+	 * Error shown when multiple scripts are detected with `FIXES_SINGLE`.
 	 */
-	FIXES_gscFixesError[] = "\7\7\7\7\7"                                                     "\n"   \
+	FIXES_gscMultiScriptError[] = "\7\7\7\7\7"                                               "\n"   \
 		"*** fixes.inc error: Running multiple scripts compiled with \"fixes.inc\"..."       "\n"   \
 		"***     Please compile your modes with \"#define FIXES_Single 0\" at the top, as"   "\n"   \
 		"***     this setting is no longer the default (to improve the more common case)."          ;
@@ -2930,6 +2986,16 @@ static stock const
 #endif
 
 /*
+ * IS_JIT
+ *
+ * True when the code is JIT compiled.
+ */
+
+#if FIX_JIT
+	#define IS_JIT (_FIXES_gIsJIT)
+#endif
+
+/*
  * IS_FILTERSCRIPT
  *
  * "FILTERSCRIPT" can't always be relied on to be set.  This is not a pre-
@@ -2937,8 +3003,55 @@ static stock const
  */
 
 #if FIX_FILTERSCRIPT
-	#define IS_FILTERSCRIPT _FIXES_gIsFilterscript
+	#define IS_FILTERSCRIPT (_FIXES_gIsFilterscript)
 #endif
+
+/*
+ * IS_WINDOWS
+ *
+ * True when the code is running on Windows.  NOT a pre-processor macro, since
+ * the OS you are running the code on can't be determined at compile-time.
+ *
+ * IS_LINUX
+ *
+ * True when the code is running on Linux.  NOT a pre-processor macro, since the
+ * OS you are running the code on can't be determined at compile-time.
+ */
+
+#if FIX_OS
+	#define IS_WINDOWS (_FIXES_gIsWindows)
+	#define IS_LINUX (!_FIXES_gIsWindows)
+#endif
+
+/*
+ * _FIXES_DetermineOS()
+ *
+ * Figure out what OS this is running on.
+ *
+ * FIXES:
+ *     IS_WINDOWS
+ *     IS_LINUX
+ */
+
+static _FIXES_DetermineOS()
+{
+	if (FIXES_gsKnownOS)
+	{
+		return;
+	}
+	FIXES_gsKnownOS = true;
+	new
+		val;
+	// The code at address 0 is always `HALT`.
+	#emit LCTRL                0
+	#emit MOVE.alt
+	#emit LCTRL                1
+	#emit SUB.alt
+	#emit STOR.S.pri           val
+	#emit LREF.S.alt           val
+	#emit STOR.S.alt           val
+	_FIXES_gIsWindows = (val == 120);
+}
 
 /*
  * File operators
@@ -3445,6 +3558,34 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 #endif
 
 /*
+ * OnJITCompile()()
+ *
+ * Set "IS_JIT" to true.
+ *
+ * FIXES:
+ *     IS_JIT
+ */
+
+forward OnJITCompile();
+
+public OnJITCompile()
+{
+	state _ALS : _ALS_go;
+	_FIXES_gIsJIT = true;
+	_FIXES_DetermineOS();
+
+	return FIXES_OnJITCompile();
+}
+
+#if defined _ALS_OnJITCompile
+	#error _ALS_OnJITCompile defined
+#endif
+#define _ALS_OnJITCompile
+#define OnJITCompile(%0) FIXES_OnJITCompile(%0) <_ALS : _ALS_go>
+
+_FIXES_FORWARD FIXES_OnJITCompile();
+
+/*
  * OnFilterScriptInit()
  *
  * Set "IS_FILTERSCRIPT" to true as this callback is ONLY called if this script
@@ -3459,13 +3600,15 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 public OnFilterScriptInit()
 {
 	// It is possible for this to be the only thing done in this function!
+	state _ALS : _ALS_go;
 	_FIXES_gIsFilterscript = true;
+	_FIXES_DetermineOS();
 
 	#if FIXES_Single
 		// Check this really IS the only script running.
 		if (existproperty(5, FIXES_gscSingleProperty))
 		{
-			print(FIXES_gscFixesError);
+			print(FIXES_gscMultiScriptError);
 		}
 		else
 		{
@@ -3564,6 +3707,7 @@ _FIXES_FORWARD FIXES_OnFilterScriptInit();
 public OnGameModeInit()
 {
 	state _ALS : _ALS_go;
+	_FIXES_DetermineOS();
 
 	#if FIXES_Single
 		// Check this really IS the only script running.  Properties reset when
@@ -3573,7 +3717,7 @@ public OnGameModeInit()
 		{
 			if (existproperty(5, FIXES_gscSingleProperty))
 			{
-				print(FIXES_gscFixesError);
+				print(FIXES_gscMultiScriptError);
 			}
 			else
 			{

--- a/fixes.inc
+++ b/fixes.inc
@@ -702,28 +702,6 @@
  * SEE:      "_FIXES_DetermineOS".
  * AUTHOR:   Y_Less (https://github.com/Y-Less)
  *
- * FIX:      print
- * PROBLEM:  Printed text doesn't show up in the console on Linux.
- * SOLUTION: Provide a second "stdout" handle and use "fwrite" to that.
- * SEE:      "FIXES_print", "_FIXES_OpenCON".
- * AUTHOR:   Y_Less (https://github.com/Y-Less)
- * AUTHOR:   OneDay (http://forum.sa-mp.com/member.php?u=266844)
- * BASED ON: http://forum.sa-mp.com/showpost.php?p=3812622
- *
- * FIX:      printf
- * PROBLEM:  Printed text doesn't show up in the console on Linux.
- * SOLUTION: Provide a second "stdout" handle and use "fwrite" to that.
- * SEE:      "FIXES_printf", "_FIXES_OpenCON".
- * AUTHOR:   Y_Less (https://github.com/Y-Less)
- * AUTHOR:   OneDay (http://forum.sa-mp.com/member.php?u=266844)
- * BASED ON: http://forum.sa-mp.com/showpost.php?p=3812622
- *
- * FIX:      printf_2
- * PROBLEM:  "print" shows "(null)" for nothing, "printf" doesn't.
- * SOLUTION: Print "(null)" for nothing.  DEFAULTS TO FALSE.
- * SEE:      "FIXES_printf".
- * AUTHOR:   Y_Less (https://github.com/Y-Less)
- *
  * ==============
  *  STYLE RULES:
  * ==============
@@ -1666,27 +1644,6 @@
 	#define FIX_OS                       (2)
 #endif
 
-#if !defined FIX_print
-	#define FIX_print                    (1)
-#elseif _FIXES_IS_UNSET(FIX_print)
-	#undef FIX_print
-	#define FIX_print                    (2)
-#endif
-
-#if !defined FIX_printf
-	#define FIX_printf                   (1)
-#elseif _FIXES_IS_UNSET(FIX_printf)
-	#undef FIX_printf
-	#define FIX_printf                   (2)
-#endif
-
-#if !defined FIX_printf_2
-	#define FIX_printf_2                 (0)
-#elseif _FIXES_IS_UNSET(FIX_printf_2)
-	#undef FIX_printf_2
-	#define FIX_printf_2                 (2)
-#endif
-
 /*
  * CHAIN_ORDER
  *
@@ -2025,37 +1982,11 @@ static stock
 	 */
 	FIXES_gsSpace[] = " ",
 	/*
-	 * File:FIXES_gsStdOut
-	 *
-	 * File handle to a fake `stdout` we can use in place of `print` and that
-	 * will actually output to the Linux console.
-	 */
-	File:FIXES_gsStdOut,
-	/*
-	 * bool:_FIXES_gsUsePrintf
-	 *
-	 * Which `printf` #emit-dependent fixes should be used.
-	 */
-	_FIXES_gsUsePrintf = 0,
-	/*
 	 * bool:FIXES_gsKnownOS
 	 *
 	 * Only determine the OS once.
 	 */
 	bool:FIXES_gsKnownOS = false,
-	/*
-	 * FIXES_gsScratchSpace[512]
-	 *
-	 * Just a large array for use in functions when they need some space for
-	 * things like string formatting.  To be shared between multiple functions
-	 * that may all need some scratch space for different reasons.  Note that
-	 * this does mean that one function using the scratch space can't call
-	 * another function also using the scratch space (at least while the data is
-	 * still live) as the second function will destroy the data from the first
-	 * function.  This is the same for recursive calls, and is the reason why
-	 * global arrays for things like strings are usually a very bad idea.
-	 */
-	FIXES_gsScratchSpace[512],
 	/*
 	 * FIXES_gsPlayersIterator[MAX_PLAYERS + 1]
 	 *
@@ -2933,19 +2864,6 @@ static stock const
 	 */
 	FIXES_gscMenuProperty[] = "FIXES_gscMenuProperty",
 	/*
-	 * FIXES_gscCONError[]
-	 *
-	 * Error shown when `stdout` (`CON`) can't be opened.  Not as neat as other
-	 * variables for line-length limit reasons.
-	 */
-	FIXES_gscCONError[] = "\7\7\7\7\7\n" \
-		"*** fixes.inc error: Could not open `CON` for console writing.  If you are\n" \
-		"***     running on Linux, please type the following in the root directory of the\n" \
-		"***     server to set up the sym link:\n" \
-		"***\n" \
-		"***         ln -s /dev/tty ./scriptfiles/CON\n" \
-		"***",
-	/*
 	 * FIXES_gscMultiScriptError[]
 	 *
 	 * Error shown when multiple scripts are detected with `FIXES_SINGLE`.
@@ -3106,26 +3024,6 @@ static stock const
 #endif
 
 /*
- * _FIXES_FunctionInclusion()
- *
- * FIXES:
- *     printf
- *     print
- *     printf_2
- */
-
-forward _FIXES_FunctionInclusion();
-
-public _FIXES_FunctionInclusion()
-{
-	// Force-include the functions in to the AMX (fixes a compiler bug with
-	// `#emit SYSREQ.C`).  Must always be included even if the fixes aren't
-	// because of another bug with `#emit` not being conditionally excluded.
-	format("", 0, "");
-	printf("");
-}
-
-/*
  * _FIXES_DetermineOS()
  *
  * Figure out what OS this is running on.
@@ -3153,42 +3051,6 @@ static _FIXES_DetermineOS()
 	#emit LREF.S.alt           val
 	#emit STOR.S.alt           val
 	_FIXES_gIsWindows = (val == 120);
-}
-
-/*
- * _FIXES_OpenCON()
- *
- * Opens `stdout` as a console write target.
- *
- * FIXES:
- *     print
- *     printf
- */
-
-static stock _FIXES_OpenCON()
-{
-	if (FIXES_gsStdOut)
-	{
-		fclose(FIXES_gsStdOut);
-	}
-	FIXES_gsStdOut = File:0;
-	if (_FIXES_gIsWindows || fexist("CON"))
-	{
-		FIXES_gsStdOut = fopen("CON", io_write);
-	}
-	if (!FIXES_gsStdOut)
-	{
-		// The file wasn't opened - this can only fail on Linux when the symlink
-		// doesn't exist and something goes horribly wrong.  Sadly, there's not
-		// a lot we can do to alert the user since on Linux `print` doesn't go
-		// to the console, but try anyway.
-		print(FIXES_gscCONError);
-	}
-	#if FIX_printf_2
-		_FIXES_gsUsePrintf = (_FIXES_gIsWindows || !FIXES_gsStdOut) ? 0 : 2;
-	#else
-		_FIXES_gsUsePrintf = (_FIXES_gIsWindows || !FIXES_gsStdOut) ? 1 : 2;
-	#endif
 }
 
 /*
@@ -3226,141 +3088,6 @@ static stock _FIXES_OpenCON()
 	forward bool:operator>=(File:a, File:b);
 	forward bool:operator>=(_:a, File:b);
 	forward bool:operator>=(File:a, _:b);
-#endif
-
-/*
- * FIXES_printf(const format[], {Float, _}:...)
- *
- * FIXES:
- *     printf
- */
-
-#if defined _ALS_printf
-	#error _ALS_printf defined
-#endif
-native BAD_printf(const fmat[], {Float, _}:...) = printf;
-
-stock FIXES_printf(const fmat[], {Float, _}:...)
-{
-		// The parameter is not called `format` like it is in the original
-		// include because having it as that name messes up the call to the
-		// function also called `format` in the `SYSREQ.C` below.  This function
-		// is NOT conditionally compiled based on `FIX_printf` because it uses
-		// `#emit` which ignores the pre-processor and so would compile wrong.
-		#pragma unused fmat
-		static
-			sFrame,
-			sReturn,
-			sCount;
-		// Store the function header.
-		#emit POP.pri
-		#emit STOR.pri         sFrame
-		#emit POP.pri
-		#emit STOR.pri         sReturn
-		// We don't need the fix on Windows, and we can't use the fix if the
-		// console redirection wasn't set up correctly.
-		if (_FIXES_gsUsePrintf == 1)
-		{
-			// Mangle the stack slightly here.  What actually happens is that
-			// because we want to call `printf` with exactly the same arguments
-			// as were passed to this function, they are already on the stack
-			// exactly as they need to be used.  So instead of looping through
-			// them all and pushing them all again (which would be an acceptable
-			// method), we just remove some data from the stack.  Call the
-			// original `printf` function.
-			#emit SYSREQ.C         printf
-			// DO NOT remove anything from the stack.  Put the header back.
-			#emit PUSH             sReturn
-			#emit PUSH             sFrame
-			// Return.
-			#emit RETN
-			// The compiler will think this will fall through, but it won't.
-		}
-		{} // Zero-cost bug fix.
-		// Store the function count.  This is the number of BYTES pushed, and
-		// needs adjusting because we need to push two extra parameters for
-		// `format` compared to `printf`.  Remove the function header.
-		#emit POP.pri
-		#emit STOR.pri         sCount
-		// Push the two additional parameters.
-		#emit PUSH.C           512
-		#emit PUSH.C           FIXES_gsScratchSpace
-		// Add the extra parameters sizes.
-		#emit ADD.C            8
-		#emit PUSH.pri
-		// Call the `format` function to create the output.
-		#emit SYSREQ.C         format
-		// Restore the function header.
-		#emit STACK            12
-		#emit PUSH             sCount
-		#emit PUSH             sReturn
-		#emit PUSH             sFrame
-		// Defer to the real `printf` method.  This is before any hooks of
-		// `print` we may have below so the redirection isn't done twice.  We
-		// use `printf` instead of `print` here to preserve `(null)` behaviour.
-	#if FIX_printf_2
-		if (FIXES_gsScratchSpace[0])
-	#endif
-		{
-			sReturn = printf(FIXES_gsScratchSpace);
-			if (_FIXES_gsUsePrintf == 2)
-			{
-				fwrite(FIXES_gsStdOut, FIXES_gsScratchSpace),
-				fwrite(FIXES_gsStdOut, FIXES_gscLF);
-			}
-		}
-	#if FIX_printf_2
-		else
-		{
-			sReturn = printf(FIXES_gscNull);
-			if (_FIXES_gsUsePrintf == 2)
-			{
-				fwrite(FIXES_gsStdOut, FIXES_gscNull),
-				fwrite(FIXES_gsStdOut, FIXES_gscLF);
-			}
-		}
-	#endif
-		return sReturn;
-}
-
-#if FIX_printf || FIX_printf_2
-	#define _ALS_printf
-	#define printf FIXES_printf
-#endif
-
-/*
- * FIXES_print(const string[])
- *
- * FIXES:
- *     print
- */
-
-#if defined _ALS_print
-	#error _ALS_print defined
-#endif
-native BAD_print(const string[]) = print;
-
-#if FIX_print
-	stock FIXES_print(const string[])
-	{
-		// This fix is very high up in the file because `print` may be used by
-		// other fixed functions in debugging, so we need the hooked `print`.
-		new
-			ret = print(string);
-		if (_FIXES_gsUsePrintf == 2)
-		{
-			// If we are not on Windows, use the opened stream to print directly
-			// to the console.  Already written to the server log by `print`.
-			// This doesn't need to conditionally write `(null)` - `print`
-			// always does that so replicate the original behaviour always.
-			fwrite(FIXES_gsStdOut, string[0] ? string : FIXES_gscNull),
-			fwrite(FIXES_gsStdOut, FIXES_gscLF);
-		}
-		return ret;
-	}
-
-	#define _ALS_print
-	#define print FIXES_print
 #endif
 
 /*
@@ -3846,9 +3573,6 @@ public OnJITCompile()
 	state _ALS : _ALS_go;
 	_FIXES_gIsJIT = true;
 	_FIXES_DetermineOS();
-	#if FIX_print || FIX_printf
-		_FIXES_OpenCON();
-	#endif
 
 	return FIXES_OnJITCompile();
 }
@@ -3879,9 +3603,6 @@ public OnFilterScriptInit()
 	state _ALS : _ALS_go;
 	_FIXES_gIsFilterscript = true;
 	_FIXES_DetermineOS();
-	#if FIX_print || FIX_printf
-		_FIXES_OpenCON();
-	#endif
 
 	#if FIXES_Single
 		// Check this really IS the only script running.
@@ -3987,9 +3708,6 @@ public OnGameModeInit()
 {
 	state _ALS : _ALS_go;
 	_FIXES_DetermineOS();
-	#if FIX_print || FIX_printf
-		_FIXES_OpenCON();
-	#endif
 
 	#if FIXES_Single
 		// Check this really IS the only script running.  Properties reset when
@@ -4081,14 +3799,9 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
  * Fast way of detecting not to retain any data.
  */
 
-#if !FIXES_Single || FIX_PlayerDialogResponse || FIX_print || FIX_printf
+#if !FIXES_Single || FIX_PlayerDialogResponse
 	public OnGameModeExit()
 	{
-		// Flush stdout by closing and reopening it.
-		#if FIX_print || FIX_printf
-			_FIXES_OpenCON();
-		#endif
-
 		#if !FIXES_Single
 			FIXES_gsSettings |= e_FIXES_SETTINGS_DROP_ALL_DATA;
 			if (!_FIXES_gIsFilterscript && FIXES_gsSettings & e_FIXES_SETTINGS_IN_CHARGE)
@@ -4129,14 +3842,9 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
  * Fast way of detecting not to retain any data.
  */
 
-#if !FIXES_Single || FIX_GameText || FIX_OnPlayerDisconnect || FIX_print || FIX_printf
+#if !FIXES_Single || FIX_GameText || FIX_OnPlayerDisconnect
 	public OnFilterScriptExit()
 	{
-		// Flush stdout by closing and reopening it.
-		#if FIX_print || FIX_printf
-			_FIXES_OpenCON();
-		#endif
-
 		#if FIX_OnPlayerDisconnect
 			// Removal safe loop.
 			for (new next, playerid = FIXES_gsPlayersIterator[MAX_PLAYERS]; playerid != MAX_PLAYERS; playerid = next)
@@ -9482,4 +9190,3 @@ native BAD_NameOfFixHere(params) = NameOfFixHere;
 	#define _ALS_NameOfFixHere
 	#define NameOfFixHere FIXES_NameOfFixHere
 #endif
-

--- a/fixes.inc
+++ b/fixes.inc
@@ -9190,3 +9190,4 @@ native BAD_NameOfFixHere(params) = NameOfFixHere;
 	#define _ALS_NameOfFixHere
 	#define NameOfFixHere FIXES_NameOfFixHere
 #endif
+

--- a/fixes.inc
+++ b/fixes.inc
@@ -702,6 +702,28 @@
  * SEE:      "_FIXES_DetermineOS".
  * AUTHOR:   Y_Less (https://github.com/Y-Less)
  *
+ * FIX:      print
+ * PROBLEM:  Printed text doesn't show up in the console on Linux.
+ * SOLUTION: Provide a second "stdout" handle and use "fwrite" to that.
+ * SEE:      "FIXES_print", "_FIXES_OpenCON".
+ * AUTHOR:   Y_Less (https://github.com/Y-Less)
+ * AUTHOR:   OneDay (http://forum.sa-mp.com/member.php?u=266844)
+ * BASED ON: http://forum.sa-mp.com/showpost.php?p=3812622
+ *
+ * FIX:      printf
+ * PROBLEM:  Printed text doesn't show up in the console on Linux.
+ * SOLUTION: Provide a second "stdout" handle and use "fwrite" to that.
+ * SEE:      "FIXES_printf", "_FIXES_OpenCON".
+ * AUTHOR:   Y_Less (https://github.com/Y-Less)
+ * AUTHOR:   OneDay (http://forum.sa-mp.com/member.php?u=266844)
+ * BASED ON: http://forum.sa-mp.com/showpost.php?p=3812622
+ *
+ * FIX:      printf_2
+ * PROBLEM:  "print" shows "(null)" for nothing, "printf" doesn't.
+ * SOLUTION: Print "(null)" for nothing.  DEFAULTS TO FALSE.
+ * SEE:      "FIXES_printf".
+ * AUTHOR:   Y_Less (https://github.com/Y-Less)
+ *
  * ==============
  *  STYLE RULES:
  * ==============
@@ -1644,6 +1666,27 @@
 	#define FIX_OS                       (2)
 #endif
 
+#if !defined FIX_print
+	#define FIX_print                    (1)
+#elseif _FIXES_IS_UNSET(FIX_print)
+	#undef FIX_print
+	#define FIX_print                    (2)
+#endif
+
+#if !defined FIX_printf
+	#define FIX_printf                   (1)
+#elseif _FIXES_IS_UNSET(FIX_printf)
+	#undef FIX_printf
+	#define FIX_printf                   (2)
+#endif
+
+#if !defined FIX_printf_2
+	#define FIX_printf_2                 (0)
+#elseif _FIXES_IS_UNSET(FIX_printf_2)
+	#undef FIX_printf_2
+	#define FIX_printf_2                 (2)
+#endif
+
 /*
  * CHAIN_ORDER
  *
@@ -1982,11 +2025,37 @@ static stock
 	 */
 	FIXES_gsSpace[] = " ",
 	/*
+	 * File:FIXES_gsStdOut
+	 *
+	 * File handle to a fake `stdout` we can use in place of `print` and that
+	 * will actually output to the Linux console.
+	 */
+	File:FIXES_gsStdOut,
+	/*
+	 * bool:_FIXES_gsUsePrintf
+	 *
+	 * Which `printf` #emit-dependent fixes should be used.
+	 */
+	_FIXES_gsUsePrintf = 0,
+	/*
 	 * bool:FIXES_gsKnownOS
 	 *
 	 * Only determine the OS once.
 	 */
 	bool:FIXES_gsKnownOS = false,
+	/*
+	 * FIXES_gsScratchSpace[512]
+	 *
+	 * Just a large array for use in functions when they need some space for
+	 * things like string formatting.  To be shared between multiple functions
+	 * that may all need some scratch space for different reasons.  Note that
+	 * this does mean that one function using the scratch space can't call
+	 * another function also using the scratch space (at least while the data is
+	 * still live) as the second function will destroy the data from the first
+	 * function.  This is the same for recursive calls, and is the reason why
+	 * global arrays for things like strings are usually a very bad idea.
+	 */
+	FIXES_gsScratchSpace[512],
 	/*
 	 * FIXES_gsPlayersIterator[MAX_PLAYERS + 1]
 	 *
@@ -2864,6 +2933,18 @@ static stock const
 	 */
 	FIXES_gscMenuProperty[] = "FIXES_gscMenuProperty",
 	/*
+	 * FIXES_gscCONError[]
+	 *
+	 * Error shown when `stdout` (`CON`) can't be opened.
+	 */
+	FIXES_gscCONError[] = "\7\7\7\7\7"                                                     "\n"   \
+		"*** fixes.inc error: Could not open `CON` for console writing.  If you are"       "\n"   \
+		"***     running on Linux, please type the following in the root directory of the" "\n"   \
+		"***     server to set up the sym link:"                                           "\n"   \
+		"***     "                                                                         "\n"   \
+		"***         ln -s /dev/tty ./scriptfiles/CON"                                     "\n"   \
+		"***     "                                                                                ,
+	/*
 	 * FIXES_gscMultiScriptError[]
 	 *
 	 * Error shown when multiple scripts are detected with `FIXES_SINGLE`.
@@ -3024,6 +3105,26 @@ static stock const
 #endif
 
 /*
+ * _FIXES_FunctionInclusion()
+ *
+ * FIXES:
+ *     printf
+ *     print
+ *     printf_2
+ */
+
+forward _FIXES_FunctionInclusion();
+
+public _FIXES_FunctionInclusion()
+{
+	// Force-include the functions in to the AMX (fixes a compiler bug with
+	// `#emit SYSREQ.C`).  Must always be included even if the fixes aren't
+	// because of another bug with `#emit` not being conditionally excluded.
+	format("", 0, "");
+	printf("");
+}
+
+/*
  * _FIXES_DetermineOS()
  *
  * Figure out what OS this is running on.
@@ -3051,6 +3152,42 @@ static _FIXES_DetermineOS()
 	#emit LREF.S.alt           val
 	#emit STOR.S.alt           val
 	_FIXES_gIsWindows = (val == 120);
+}
+
+/*
+ * _FIXES_OpenCON()
+ *
+ * Opens `stdout` as a console write target.
+ *
+ * FIXES:
+ *     print
+ *     printf
+ */
+
+static stock _FIXES_OpenCON()
+{
+	if (FIXES_gsStdOut)
+	{
+		fclose(FIXES_gsStdOut);
+	}
+	FIXES_gsStdOut = File:0;
+	if (_FIXES_gIsWindows || fexist("CON"))
+	{
+		FIXES_gsStdOut = fopen("CON", io_write);
+	}
+	if (!FIXES_gsStdOut)
+	{
+		// The file wasn't opened - this can only fail on Linux when the symlink
+		// doesn't exist and something goes horribly wrong.  Sadly, there's not
+		// a lot we can do to alert the user since on Linux `print` doesn't go
+		// to the console, but try anyway.
+		print(FIXES_gscCONError);
+	}
+	#if FIX_printf_2
+		_FIXES_gsUsePrintf = (_FIXES_gIsWindows || !FIXES_gsStdOut) ? 0 : 2;
+	#else
+		_FIXES_gsUsePrintf = (_FIXES_gIsWindows || !FIXES_gsStdOut) ? 1 : 2;
+	#endif
 }
 
 /*
@@ -3088,6 +3225,141 @@ static _FIXES_DetermineOS()
 	forward bool:operator>=(File:a, File:b);
 	forward bool:operator>=(_:a, File:b);
 	forward bool:operator>=(File:a, _:b);
+#endif
+
+/*
+ * FIXES_printf(const format[], {Float, _}:...)
+ *
+ * FIXES:
+ *     printf
+ */
+
+#if defined _ALS_printf
+	#error _ALS_printf defined
+#endif
+native BAD_printf(const fmat[], {Float, _}:...) = printf;
+
+stock FIXES_printf(const fmat[], {Float, _}:...)
+{
+		// The parameter is not called `format` like it is in the original
+		// include because having it as that name messes up the call to the
+		// function also called `format` in the `SYSREQ.C` below.  This function
+		// is NOT conditionally compiled based on `FIX_printf` because it uses
+		// `#emit` which ignores the pre-processor and so would compile wrong.
+		#pragma unused fmat
+		static
+			sFrame,
+			sReturn,
+			sCount;
+		// Store the function header.
+		#emit POP.pri
+		#emit STOR.pri         sFrame
+		#emit POP.pri
+		#emit STOR.pri         sReturn
+		// We don't need the fix on Windows, and we can't use the fix if the
+		// console redirection wasn't set up correctly.
+		if (_FIXES_gsUsePrintf == 1)
+		{
+			// Mangle the stack slightly here.  What actually happens is that
+			// because we want to call `printf` with exactly the same arguments
+			// as were passed to this function, they are already on the stack
+			// exactly as they need to be used.  So instead of looping through
+			// them all and pushing them all again (which would be an acceptable
+			// method), we just remove some data from the stack.  Call the
+			// original `printf` function.
+			#emit SYSREQ.C         printf
+			// DO NOT remove anything from the stack.  Put the header back.
+			#emit PUSH             sReturn
+			#emit PUSH             sFrame
+			// Return.
+			#emit RETN
+			// The compiler will think this will fall through, but it won't.
+		}
+		{} // Zero-cost bug fix.
+		// Store the function count.  This is the number of BYTES pushed, and
+		// needs adjusting because we need to push two extra parameters for
+		// `format` compared to `printf`.  Remove the function header.
+		#emit POP.pri
+		#emit STOR.pri         sCount
+		// Push the two additional parameters.
+		#emit PUSH.C           512
+		#emit PUSH.C           FIXES_gsScratchSpace
+		// Add the extra parameters sizes.
+		#emit ADD.C            8
+		#emit PUSH.pri
+		// Call the `format` function to create the output.
+		#emit SYSREQ.C         format
+		// Restore the function header.
+		#emit STACK            12
+		#emit PUSH             sCount
+		#emit PUSH             sReturn
+		#emit PUSH             sFrame
+		// Defer to the real `printf` method.  This is before any hooks of
+		// `print` we may have below so the redirection isn't done twice.  We
+		// use `printf` instead of `print` here to preserve `(null)` behaviour.
+	#if FIX_printf_2
+		if (FIXES_gsScratchSpace[0])
+	#endif
+		{
+			sReturn = printf(FIXES_gsScratchSpace);
+			if (_FIXES_gsUsePrintf == 2)
+			{
+				fwrite(FIXES_gsStdOut, FIXES_gsScratchSpace),
+				fwrite(FIXES_gsStdOut, FIXES_gscLF);
+			}
+		}
+	#if FIX_printf_2
+		else
+		{
+			sReturn = printf(FIXES_gscNull);
+			if (_FIXES_gsUsePrintf == 2)
+			{
+				fwrite(FIXES_gsStdOut, FIXES_gscNull),
+				fwrite(FIXES_gsStdOut, FIXES_gscLF);
+			}
+		}
+	#endif
+		return sReturn;
+}
+
+#if FIX_printf || FIX_printf_2
+	#define _ALS_printf
+	#define printf FIXES_printf
+#endif
+
+/*
+ * FIXES_print(const string[])
+ *
+ * FIXES:
+ *     print
+ */
+
+#if defined _ALS_print
+	#error _ALS_print defined
+#endif
+native BAD_print(const string[]) = print;
+
+#if FIX_print
+	stock FIXES_print(const string[])
+	{
+		// This fix is very high up in the file because `print` may be used by
+		// other fixed functions in debugging, so we need the hooked `print`.
+		new
+			ret = print(string);
+		if (_FIXES_gsUsePrintf == 2)
+		{
+			// If we are not on Windows, use the opened stream to print directly
+			// to the console.  Already written to the server log by `print`.
+			// This doesn't need to conditionally write `(null)` - `print`
+			// always does that so replicate the original behaviour always.
+			fwrite(FIXES_gsStdOut, string[0] ? string : FIXES_gscNull),
+			fwrite(FIXES_gsStdOut, FIXES_gscLF);
+		}
+		return ret;
+	}
+
+	#define _ALS_print
+	#define print FIXES_print
 #endif
 
 /*
@@ -3573,6 +3845,9 @@ public OnJITCompile()
 	state _ALS : _ALS_go;
 	_FIXES_gIsJIT = true;
 	_FIXES_DetermineOS();
+	#if FIX_print || FIX_printf
+		_FIXES_OpenCON();
+	#endif
 
 	return FIXES_OnJITCompile();
 }
@@ -3603,6 +3878,9 @@ public OnFilterScriptInit()
 	state _ALS : _ALS_go;
 	_FIXES_gIsFilterscript = true;
 	_FIXES_DetermineOS();
+	#if FIX_print || FIX_printf
+		_FIXES_OpenCON();
+	#endif
 
 	#if FIXES_Single
 		// Check this really IS the only script running.
@@ -3708,6 +3986,9 @@ public OnGameModeInit()
 {
 	state _ALS : _ALS_go;
 	_FIXES_DetermineOS();
+	#if FIX_print || FIX_printf
+		_FIXES_OpenCON();
+	#endif
 
 	#if FIXES_Single
 		// Check this really IS the only script running.  Properties reset when
@@ -3799,9 +4080,14 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
  * Fast way of detecting not to retain any data.
  */
 
-#if !FIXES_Single || FIX_PlayerDialogResponse
+#if !FIXES_Single || FIX_PlayerDialogResponse || FIX_print || FIX_printf
 	public OnGameModeExit()
 	{
+		// Flush stdout by closing and reopening it.
+		#if FIX_print || FIX_printf
+			_FIXES_OpenCON();
+		#endif
+
 		#if !FIXES_Single
 			FIXES_gsSettings |= e_FIXES_SETTINGS_DROP_ALL_DATA;
 			if (!_FIXES_gIsFilterscript && FIXES_gsSettings & e_FIXES_SETTINGS_IN_CHARGE)
@@ -3842,9 +4128,14 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
  * Fast way of detecting not to retain any data.
  */
 
-#if !FIXES_Single || FIX_GameText || FIX_OnPlayerDisconnect
+#if !FIXES_Single || FIX_GameText || FIX_OnPlayerDisconnect || FIX_print || FIX_printf
 	public OnFilterScriptExit()
 	{
+		// Flush stdout by closing and reopening it.
+		#if FIX_print || FIX_printf
+			_FIXES_OpenCON();
+		#endif
+
 		#if FIX_OnPlayerDisconnect
 			// Removal safe loop.
 			for (new next, playerid = FIXES_gsPlayersIterator[MAX_PLAYERS]; playerid != MAX_PLAYERS; playerid = next)
@@ -9190,3 +9481,4 @@ native BAD_NameOfFixHere(params) = NameOfFixHere;
 	#define _ALS_NameOfFixHere
 	#define NameOfFixHere FIXES_NameOfFixHere
 #endif
+

--- a/fixes.inc
+++ b/fixes.inc
@@ -2935,15 +2935,16 @@ static stock const
 	/*
 	 * FIXES_gscCONError[]
 	 *
-	 * Error shown when `stdout` (`CON`) can't be opened.
+	 * Error shown when `stdout` (`CON`) can't be opened.  Not as neat as other
+	 * variables for line-length limit reasons.
 	 */
-	FIXES_gscCONError[] = "\7\7\7\7\7"                                                     "\n"   \
-		"*** fixes.inc error: Could not open `CON` for console writing.  If you are"       "\n"   \
-		"***     running on Linux, please type the following in the root directory of the" "\n"   \
-		"***     server to set up the sym link:"                                           "\n"   \
-		"***     "                                                                         "\n"   \
-		"***         ln -s /dev/tty ./scriptfiles/CON"                                     "\n"   \
-		"***     "                                                                                ,
+	FIXES_gscCONError[] = "\7\7\7\7\7\n" \
+		"*** fixes.inc error: Could not open `CON` for console writing.  If you are\n" \
+		"***     running on Linux, please type the following in the root directory of the\n" \
+		"***     server to set up the sym link:\n" \
+		"***\n" \
+		"***         ln -s /dev/tty ./scriptfiles/CON\n" \
+		"***",
 	/*
 	 * FIXES_gscMultiScriptError[]
 	 *

--- a/fixes.inc
+++ b/fixes.inc
@@ -1910,13 +1910,14 @@ stock
 	 */
 	bool:_FIXES_gIsFilterscript;
 
-stock
+stock const
 	/*
-	 * FIXES_gscSpace[]
+	 * FIXES_gcSpace[]
 	 *
-	 * A single re-usable space.
+	 * A single re-usable space.  Const not static because it is used in macros
+	 * `HideGameTextForAll` and `HideGameTextForPlayer`.
 	 */
-	FIXES_gscSpace[] = " ";
+	FIXES_gcSpace[] = " ";
 
 #if FIXES_Debug
 new
@@ -1924,9 +1925,16 @@ new
 static stock
 #endif
 	/*
-	 * FIXES_gsValidMenus[_FIXES_CEILDIV(MAX_MENUS, cellbits)]
+	 * FIXES_gsSpace[]
 	 *
-	 * A record of which menus have and haven't been shown yet.  We ensure that
+	 * A single re-usable space.  Static not const because it is used in this
+	 * file in functions that don't take `const` strings.
+	 */
+	FIXES_gsSpace[] = " ",
+	/*
+	 * FIXES_gsPlayersIterator[MAX_PLAYERS + 1]
+	 *
+	 * A record of which players are connected to the server.  We ensure that
 	 * this only exists when required, since it depends on add and remove
 	 * functions to be called at the right time.
 	 */
@@ -2275,6 +2283,18 @@ static stock
 	FIXES_gscNULL[] = "\1";
 
 static stock const
+	/*
+	 * FIXES_gscNull[]
+	 *
+	 * (null).  This is stored as a global string to reduce memory usage.
+	 */
+	FIXES_gscNull[] = "(null)",
+	/*
+	 * FIXES_gscLF[]
+	 *
+	 * A single re-usable new line.
+	 */
+	FIXES_gscLF[] = "\n",
 	/*
 	 * FIXES_gscPlayerColours[100]
 	 *
@@ -3019,7 +3039,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 			#if FIX_GameTextStyles
 
 				// Global style 7 (vehicle name).
-				t = FIXES_gsGTStyle[7] = TextDrawCreate(608.000000, 344.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[7] = TextDrawCreate(608.000000, 344.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.000000, 3.000000),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0x36682CFF),
@@ -3033,7 +3053,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 8 (location name).
-				t = FIXES_gsGTStyle[8] = TextDrawCreate(608.000000, 386.500000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[8] = TextDrawCreate(608.000000, 386.500000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.200000, 3.799998),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0xACCBF1FF),
@@ -3047,7 +3067,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 9 (radio name).
-				t = FIXES_gsGTStyle[9] = TextDrawCreate(320.000000, 22.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[9] = TextDrawCreate(320.000000, 22.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.600000, 1.899999),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x906210FF),
@@ -3061,7 +3081,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 10 (radio switch).
-				t = FIXES_gsGTStyle[10] = TextDrawCreate(320.000000, 22.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[10] = TextDrawCreate(320.000000, 22.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.600000, 1.899999),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x969696FF),
@@ -3075,7 +3095,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 11 (positive money).
-				t = FIXES_gsGTStyle[11] = TextDrawCreate(607.000000, 78.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[11] = TextDrawCreate(607.000000, 78.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.550000, 2.150000),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0x36682CFF),
@@ -3089,7 +3109,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 12 (negative money).
-				t = FIXES_gsGTStyle[12] = TextDrawCreate(607.000000, 78.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[12] = TextDrawCreate(607.000000, 78.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.550000, 2.150000),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0xB4191DFF),
@@ -3103,7 +3123,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 13 (stunt).
-				t = FIXES_gsGTStyle[13] = TextDrawCreate(380.000000, 341.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[13] = TextDrawCreate(380.000000, 341.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.579999, 2.400000),
 				TextDrawTextSize(t, 40.000000, 460.000000),
 				TextDrawAlignment(t, 2),
@@ -3119,7 +3139,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 			#endif
 
 				// Global style 0.
-				t = FIXES_gsGTStyle[0] = TextDrawCreate(320.0, 214.0, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[0] = TextDrawCreate(320.0, 214.0, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.3, 3.6),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x906210FF),
@@ -3133,7 +3153,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 1.
-				t = FIXES_gsGTStyle[1] = TextDrawCreate(620.0, 310.0, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[1] = TextDrawCreate(620.0, 310.0, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.0, 2.6),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0x906210FF),
@@ -3147,7 +3167,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 2.
-				t = FIXES_gsGTStyle[2] = TextDrawCreate(320.0, 156.0, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[2] = TextDrawCreate(320.0, 156.0, FIXES_gsSpace),
 				TextDrawLetterSize(t, 2.1, 4.2),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0xE1E1E1FF),
@@ -3161,7 +3181,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 3.
-				t = FIXES_gsGTStyle[3] = TextDrawCreate(320.000000, 154.500000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[3] = TextDrawCreate(320.000000, 154.500000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.600000, 2.750000),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x906210FF),
@@ -3175,7 +3195,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 4.
-				t = FIXES_gsGTStyle[4] = TextDrawCreate(320.000000, 115.500000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[4] = TextDrawCreate(320.000000, 115.500000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.600000, 2.750000),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x906210FF),
@@ -3189,7 +3209,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 5.
-				t = FIXES_gsGTStyle[5] = TextDrawCreate(320.0, 217.0, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[5] = TextDrawCreate(320.0, 217.0, FIXES_gsSpace),
 				TextDrawLetterSize(t, 0.6, 2.75),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0xE1E1E1FF),
@@ -3203,7 +3223,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 6.
-				t = FIXES_gsGTStyle[6] = TextDrawCreate(320.000000, 60.000000, FIXES_gscSpace),
+				t = FIXES_gsGTStyle[6] = TextDrawCreate(320.000000, 60.000000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.000000, 3.599998),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0xACCBF1FF),
@@ -3224,7 +3244,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 			#if FIX_GameTextStyles
 
 				// Global style 7 (playerid, vehicle name).
-				t = FIXES_gsPGTStyle[playerid][7] = CreatePlayerTextDraw(playerid, 608.000000, 344.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][7] = CreatePlayerTextDraw(playerid, 608.000000, 344.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.000000, 3.000000),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0x36682CFF),
@@ -3238,7 +3258,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 8 (playerid, location name).
-				t = FIXES_gsPGTStyle[playerid][8] = CreatePlayerTextDraw(playerid, 608.000000, 386.500000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][8] = CreatePlayerTextDraw(playerid, 608.000000, 386.500000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.200000, 3.799998),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0xACCBF1FF),
@@ -3252,7 +3272,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 9 (playerid, radio name).
-				t = FIXES_gsPGTStyle[playerid][9] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][9] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.899999),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
@@ -3266,7 +3286,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 10 (playerid, radio switch).
-				t = FIXES_gsPGTStyle[playerid][10] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][10] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.899999),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x969696FF),
@@ -3280,7 +3300,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 11 (playerid, positive money).
-				t = FIXES_gsPGTStyle[playerid][11] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][11] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.150000),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0x36682CFF),
@@ -3294,7 +3314,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 12 (playerid, negative money).
-				t = FIXES_gsPGTStyle[playerid][12] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][12] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.150000),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0xB4191DFF),
@@ -3308,7 +3328,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 13 (playerid, stunt).
-				t = FIXES_gsPGTStyle[playerid][13] = CreatePlayerTextDraw(playerid, 380.000000, 341.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][13] = CreatePlayerTextDraw(playerid, 380.000000, 341.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.579999, 2.400000),
 				PlayerTextDrawTextSize(playerid, t, 40.000000, 460.000000),
 				PlayerTextDrawAlignment(playerid, t, 2),
@@ -3324,7 +3344,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 			#endif
 
 				// Global style 0.
-				t = FIXES_gsPGTStyle[playerid][0] = CreatePlayerTextDraw(playerid, 320.0, 214.0, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][0] = CreatePlayerTextDraw(playerid, 320.0, 214.0, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.3, 3.6),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
@@ -3338,7 +3358,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 1.
-				t = FIXES_gsPGTStyle[playerid][1] = CreatePlayerTextDraw(playerid, 620.0, 310.0, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][1] = CreatePlayerTextDraw(playerid, 620.0, 310.0, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.0, 2.6),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
@@ -3352,7 +3372,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 2.
-				t = FIXES_gsPGTStyle[playerid][2] = CreatePlayerTextDraw(playerid, 320.0, 156.0, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][2] = CreatePlayerTextDraw(playerid, 320.0, 156.0, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 2.1, 4.2),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0xE1E1E1FF),
@@ -3366,7 +3386,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 3.
-				t = FIXES_gsPGTStyle[playerid][3] = CreatePlayerTextDraw(playerid, 320.000000, 154.500000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][3] = CreatePlayerTextDraw(playerid, 320.000000, 154.500000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.600000, 2.750000),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
@@ -3380,7 +3400,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 4.
-				t = FIXES_gsPGTStyle[playerid][4] = CreatePlayerTextDraw(playerid, 320.000000, 115.500000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][4] = CreatePlayerTextDraw(playerid, 320.000000, 115.500000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.600000, 2.750000),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
@@ -3394,7 +3414,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 5.
-				t = FIXES_gsPGTStyle[playerid][5] = CreatePlayerTextDraw(playerid, 320.0, 217.0, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][5] = CreatePlayerTextDraw(playerid, 320.0, 217.0, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 0.6, 2.75),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0xE1E1E1FF),
@@ -3408,7 +3428,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 6.
-				t = FIXES_gsPGTStyle[playerid][6] = CreatePlayerTextDraw(playerid, 320.000000, 60.000000, FIXES_gscSpace),
+				t = FIXES_gsPGTStyle[playerid][6] = CreatePlayerTextDraw(playerid, 320.000000, 60.000000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.000000, 3.599998),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0xACCBF1FF),
@@ -3440,8 +3460,6 @@ public OnFilterScriptInit()
 {
 	// It is possible for this to be the only thing done in this function!
 	_FIXES_gIsFilterscript = true;
-
-	state _ALS : _ALS_go;
 
 	#if FIXES_Single
 		// Check this really IS the only script running.
@@ -3655,7 +3673,7 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
 		#if FIX_PlayerDialogResponse
 			for (new playerid = 0; playerid != MAX_PLAYERS; ++playerid)
 			{
-				ShowPlayerDialog(playerid, -1, 0, FIXES_gscSpace, FIXES_gscSpace, FIXES_gscSpace, FIXES_gscSpace);
+				ShowPlayerDialog(playerid, -1, 0, FIXES_gsSpace, FIXES_gsSpace, FIXES_gsSpace, FIXES_gsSpace);
 			}
 		#endif
 		// =============================
@@ -4008,7 +4026,7 @@ _FIXES_FORWARD FIXES_OnGameModeInit();
 				//  BEGIN: PlayerDialogResponse
 				// =============================
 				#if FIX_PlayerDialogResponse
-					ShowPlayerDialog(playerid, -1, 0, FIXES_gscSpace, FIXES_gscSpace, FIXES_gscSpace, FIXES_gscSpace);
+					ShowPlayerDialog(playerid, -1, 0, FIXES_gsSpace, FIXES_gsSpace, FIXES_gsSpace, FIXES_gsSpace);
 				#endif
 				// =============================
 				//  END:   PlayerDialogResponse
@@ -6764,9 +6782,9 @@ native BAD_GameTextForAll(const string[], time, style) = GameTextForAll;
 			if ((string[0] == '\0') || (string[0] == '\1' && string[1] == '\0'))
 			{
 				#if FIXES_Single
-					return _FIXES_GameTextShow(MAX_PLAYERS, FIXES_gscSpace, time, style);
+					return _FIXES_GameTextShow(MAX_PLAYERS, FIXES_gsSpace, time, style);
 				#else
-					return CallRemoteFunction(FIXES_gscGameTextShow, FIXES_gscSpec@isii, MAX_PLAYERS, FIXES_gscSpace, time, style);
+					return CallRemoteFunction(FIXES_gscGameTextShow, FIXES_gscSpec@isii, MAX_PLAYERS, FIXES_gsSpace, time, style);
 				#endif
 			}
 			else
@@ -6806,9 +6824,9 @@ native BAD_GameTextForPlayer(playerid, const string[], time, style) = GameTextFo
 			if ((string[0] <= '\0') || (string[0] == '\1' && string[1] == '\0'))
 			{
 				#if FIXES_Single
-					return _FIXES_GameTextShow(playerid, FIXES_gscSpace, time, style);
+					return _FIXES_GameTextShow(playerid, FIXES_gsSpace, time, style);
 				#else
-					return CallRemoteFunction(FIXES_gscGameTextShow, FIXES_gscSpec@isii, playerid, FIXES_gscSpace, time, style);
+					return CallRemoteFunction(FIXES_gscGameTextShow, FIXES_gscSpec@isii, playerid, FIXES_gsSpace, time, style);
 				#endif
 			}
 			else
@@ -6843,7 +6861,7 @@ native BAD_HideGameTextForAll(style) = HideGameTextForAll;
 #if FIX_HideGameText
 	#define _ALS_HideGameTextForAll
 
-	#define HideGameTextForAll(%0) GameTextForAll(FIXES_gscSpace, 0, (%0))
+	#define HideGameTextForAll(%0) GameTextForAll(FIXES_gcSpace, 0, (%0))
 #endif
 
 /*
@@ -6861,7 +6879,7 @@ native BAD_HideGameTextForPlayer(playerid, style) = HideGameTextForPlayer;
 #if FIX_HideGameText
 	#define _ALS_HideGameTextForPlayer
 
-	#define HideGameTextForPlayer(%1,%0) GameTextForPlayer((%1), FIXES_gscSpace, 0, (%0))
+	#define HideGameTextForPlayer(%1,%0) GameTextForPlayer((%1), FIXES_gcSpace, 0, (%0))
 #endif
 
 /*
@@ -6881,7 +6899,7 @@ native Text:BAD_CreatePlayerTextDraw(playerid, Float:x, Float:y, text[]) = Creat
 	{
 		if ((text[0] == '\0') || (text[0] == '\1' && text[1] == '\0'))
 		{
-			return CreatePlayerTextDraw(playerid, x, y, FIXES_gscSpace);
+			return CreatePlayerTextDraw(playerid, x, y, FIXES_gsSpace);
 		}
 		else
 		{
@@ -6910,7 +6928,7 @@ native BAD_PlayerTextDrawSetString(playerid, PlayerText:text, string[]) = Player
 	{
 		if ((string[0] == '\0') || (string[0] == '\1' && string[1] == '\0'))
 		{
-			return PlayerTextDrawSetString(playerid, text, FIXES_gscSpace);
+			return PlayerTextDrawSetString(playerid, text, FIXES_gsSpace);
 		}
 		else
 		{
@@ -6938,7 +6956,7 @@ native Text:BAD_TextDrawCreate(Float:x, Float:y, text[]) = TextDrawCreate;
 	{
 		if ((text[0] == '\0') || (text[0] == '\1' && text[1] == '\0'))
 		{
-			return TextDrawCreate(x, y, FIXES_gscSpace);
+			return TextDrawCreate(x, y, FIXES_gsSpace);
 		}
 		else
 		{
@@ -6968,7 +6986,7 @@ native BAD_TextDrawSetString(Text:text, string[]) = TextDrawSetString;
 	{
 		if ((string[0] == '\0') || (string[0] == '\1' && string[1] == '\0'))
 		{
-			return TextDrawSetString(text, FIXES_gscSpace);
+			return TextDrawSetString(text, FIXES_gsSpace);
 		}
 		else
 		{


### PR DESCRIPTION
One is an internal fix - making `FIXES_gscSpace` actually `const` in as many places as possible.  Specifically, all user-facing uses are `const` meaning that no-one can accidentally change the string.  The only functions that don't take a `const` string are only used within the library itself so the variable can be made `static` instead to prevent external modifications.  This means there are now two space strings, but that's not a major issue.

The second isn't really a "fix", but is in line with the existing `IS_FILTERSCRIPT` variable - just adds `IS_JIT`, `IS_WINDOWS` and `IS_LINUX` tests (should maybe also have `IS_GAMEMODE` and `IS_NPCMODE`, but currently don't, in fact I don't think this supports NPC modes at all).

The last one is to actually print in the console on Linux, instead of `print` only going to `server.log`.  It uses a trick from this topic:

http://forum.sa-mp.com/showthread.php?p=3812622#post3812622

Which requires an additional command to actually work on Linux:

```
ln -s /dev/tty ./scriptfiles/CON
```