### PR TITLE
Changed BODY_PARTS back to standard definition

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -2952,8 +2952,8 @@ static stock const
  */
 
 #if FIX_BODYPARTS
-	#define BODY_PART_TORSO                     (3)
-	#define BODY_PART_GROIN                     (4)
+	#define BODY_PART_CHEST                     (3)
+	#define BODY_PART_TORSO                     (4)
 	#define BODY_PART_LEFT_ARM                  (5)
 	#define BODY_PART_RIGHT_ARM                 (6)
 	#define BODY_PART_LEFT_LEG                  (7)


### PR DESCRIPTION
The previous definition was going against what is documented in the wiki.
See: http://wiki.sa-mp.com/wiki/Body_Parts.
I think this is code breaking and if someone only uses ```BODY_PART_TORSO```, his code will break without even a warning.
So I think keeping them standard is the best choice, even if the known standard method is not 'the best', it's what it is....
I could understand why you changed the name at first, but is it really necessary to make 2 different versions of those?
Thank you,
rt-2