### PR TITLE
Gametext should not be remove on spawn?

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -5020,24 +5020,6 @@ native BAD_SetPlayerName(playerid, const name[]) = SetPlayerName;
 
 				#undef _FIXES_PER_PLAYER_GT
 
-				// Global GTs.
-				#if FIX_GameTextStyles
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[13]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[12]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[11]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[10]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[9]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[8]),
-					TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[7]);
-				#endif
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[6]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[5]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[4]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[3]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[2]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[1]),
-				TextDrawHideForPlayer(playerid, FIXES_gsGTStyle[0]);
-
 			#endif
 			// =================
 			//  END:   GameText


### PR DESCRIPTION
Hi,
I'm not sure I am 100% right here, but look.
I had problem and I didn't know why my gametext wouldn't show on connection if I enabled this fix.
Then I realized it was because I was spawning the player.
The thing is I used a gametext to show a "Please Wait" message while I do my operation behind a black screen, involving but not limited to, spawning the player.
I don't think we should remove the GameTexts on spawn. I do understand where the idea is coming from, but this is not the default behavior nor a bug, so I think we should keep it that way if there is no other problem I am not aware of.
I think we should not remove the GameTexts on spawn simply because it is not the normal behavior and our goal is not to change anything, just fix bugs. But the debate is opened.
Thank you,
rt-2