### PR TITLE
A little optimisation to FIX_PassengerSeating and FIX_SetPlayerPos

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -5658,7 +5658,7 @@ native BAD_GetWeaponName(weaponid, weapon[], len) = GetWeaponName;
 		//  END:   SetPlayerWorldBounds
 		// =============================
 
-		#if FIX_OnPlayerDeath || FIX_PassengerSeating
+		#if FIX_OnPlayerDeath
 			new
 				animation = GetPlayerAnimationIndex(playerid);
 		#endif
@@ -5711,6 +5711,11 @@ native BAD_GetWeaponName(weaponid, weapon[], len) = GetWeaponName;
 			{
 				if (GetPlayerSpecialAction(playerid) == SPECIAL_ACTION_ENTER_VEHICLE)
 				{
+					#if !FIX_OnPlayerDeath
+						new
+							animation = GetPlayerAnimationIndex(playerid);
+					#endif
+
 					if (!(1007 <= animation <= 1060) && !(225 <= animation <= 233))
 					{
 						ClearAnimations(playerid, 1);

--- a/fixes.inc
+++ b/fixes.inc
@@ -5658,16 +5658,12 @@ native BAD_GetWeaponName(weaponid, weapon[], len) = GetWeaponName;
 		//  END:   SetPlayerWorldBounds
 		// =============================
 
-		#if FIX_OnPlayerDeath
-			new
-				animation = GetPlayerAnimationIndex(playerid);
-		#endif
-
 		// ======================
 		//  BEGIN: OnPlayerDeath
 		// ======================
 		#if FIX_OnPlayerDeath
-			FIXES_gsLastAnimation[playerid] = animation;
+			new
+				animation = FIXES_gsLastAnimation[playerid] = GetPlayerAnimationIndex(playerid);
 		#endif
 		// ======================
 		//  END:   OnPlayerDeath
@@ -5716,7 +5712,7 @@ native BAD_GetWeaponName(weaponid, weapon[], len) = GetWeaponName;
 							animation = GetPlayerAnimationIndex(playerid);
 					#endif
 
-					if (!(1007 <= animation <= 1060) && !(225 <= animation <= 233))
+					if (_FIXES_NO_RANGE(animation, 1007, 1060 + 1) && _FIXES_NO_RANGE(animation, 225, 233 + 1))
 					{
 						ClearAnimations(playerid, 1);
 						FIXES_gsPSTimer[playerid] = 0;
@@ -9756,9 +9752,13 @@ native BAD_SetPlayerPos(playerid, Float:x, Float:y, Float:z) = SetPlayerPos;
 	stock FIXES_SetPlayerPos(playerid, Float:x, Float:y, Float:z)
 	{
 		new
-			ret = SetPlayerPos(playerid, x, y, z),
-			index = GetPlayerAnimationIndex(playerid);
-		switch (index)
+			ret = SetPlayerPos(playerid, x, y, z);
+
+		#if FIX_OnPlayerDeath
+		switch (FIXES_gsLastAnimation[playerid])
+		#else
+		switch (GetPlayerAnimationIndex(playerid))
+		#endif
 		{
 			case 958, 959, 960, 961, 962, 1134:
 			{


### PR DESCRIPTION
If ```FIX_OnPlayerDeath``` isn't used, there's no need to get the animation in every call of ```OnPlayerUpdate```, only if ```FIX_PassengerSeating``` is used. Well, there is a pretty low chance of this being a case, but still, could improve ```OnPlayerUpdate``` a bit in some cases.