### PR TITLE
Fix position of the 'location name' textdraws

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -3857,7 +3857,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 8 (location name).
-				t = FIXES_gsGTStyle[8] = TextDrawCreate(608.000000, 386.500000, FIXES_gsSpace),
+				t = FIXES_gsGTStyle[8] = TextDrawCreate(608.000000, 385.800000, FIXES_gsSpace),
 				TextDrawLetterSize(t, 1.200000, 3.799998),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0xACCBF1FF),
@@ -4062,7 +4062,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 8 (playerid, location name).
-				t = FIXES_gsPGTStyle[playerid][8] = CreatePlayerTextDraw(playerid, 608.000000, 386.500000, FIXES_gsSpace),
+				t = FIXES_gsPGTStyle[playerid][8] = CreatePlayerTextDraw(playerid, 608.000000, 385.800000, FIXES_gsSpace),
 				PlayerTextDrawLetterSize(playerid, t, 1.200000, 3.799998),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0xACCBF1FF),


### PR DESCRIPTION
При пересоздании интерфейса синглплеера заметил реализацию отдельных его частей в данном инклуде. Так вот, новый gametext, отображающий название локации, чуть смещён вниз по сравнению с тем, который отображается в одиночной игре.

Вот некоторые скрины для сравнения (кликните по ним для увеличения, чтобы увидеть более детальную разницу):

(Eng):
When I was working on recreating interface from singleplayer I noticed the implementation of these some parts in this include. So, the new gametext that displays the name of the location is slightly biased down compared to what is displayed in singleplayer game.

Here are some screenshots to compare (click on them to zoom in and to see a more detailed difference):

Original
![http://imgur.com/a/jaaod](http://i.imgur.com/jmH8Ahk.jpg)

Textdraw
![http://imgur.com/a/cMei5](http://i.imgur.com/NOaSpen.jpg)


After position fix
![http://imgur.com/a/TqDJi](http://i.imgur.com/9Bv7bOI.jpg)