### PR TITLE
Fix strcmp (#66)

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -9906,11 +9906,18 @@ native BAD_strcmp(const string1[], const string2[], bool:ignorecase=false, lengt
 #if FIX_strcmp
 	stock FIXES_strcmp(const string1[], const string2[], bool:ignorecase=false, length=cellmax)
 	{
+		if (length == 0)
+			return 0;
 		if (string1[0])
 		{
 			if (string2[0])
 			{
-				return strcmp(string1, string2, ignorecase, length);
+				static result;
+				if (_FIXES_IN_RANGE((result = strcmp(string1, string2, ignorecase, length)), -1, 1))
+					return result;
+				if (result > 0)
+					return 1;
+				return -1;
 			}
 			else
 			{


### PR DESCRIPTION
The test code can be found here: https://github.com/Daniel-Cortez/pawn-3.2-plus/blob/master/examples/strcmp_test.p
I originally used it for fixing `strcmp` itself (in amxstring.c), but it should be suitable here as well. Just add `#include <a_samp>` and `#include <fixes>` and it should work.

I had the following output without the fix:
```Pawn
strcmp("", "", false, 2147483647): 0 (should be 0)
strcmp("", "", false, 0): 0 (should be 0)
strcmp("", "", false, 1): 0 (should be 0)
strcmp("", "", false, 2): 0 (should be 0)
strcmp("abcdef", "", false, 2147483647): 1 (should be 1)
strcmp("", "abcdef", false, 2147483647): -1 (should be -1)
strcmp("abcdef", "", false, 0): 1 (should be 0)
strcmp("", "abcdef", false, 0): -1 (should be 0)
strcmp("abcdef", "abcdef", false, 2147483647): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 2147483647): 1 (should be 1)
strcmp("abcdef", "abcxyz", false, 2147483647): -1 (should be -1)
strcmp("abcdef", "abcdef", false, 0): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 0): 0 (should be 0)
strcmp("abcdef", "abcxyz", false, 0): 0 (should be 0)
strcmp("abcdef", "abcdef", false, 3): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 3): 0 (should be 0)
strcmp("abcdef", "abcxyz", false, 3): 0 (should be 0)
strcmp("abcdef", "abc", false, 2147483647): 3 (should be 1)
strcmp("abc", "abcdef", false, 2147483647): -3 (should be -1)
strcmp("abcdef", "abc", false, 5): 3 (should be 1)
strcmp("abc", "abcdef", false, 5): -3 (should be -1)
15/21 passed, 6/21 failed
```
And with the fix from this PR:
```Pawn
strcmp("", "", false, 2147483647): 0 (should be 0)
strcmp("", "", false, 0): 0 (should be 0)
strcmp("", "", false, 1): 0 (should be 0)
strcmp("", "", false, 2): 0 (should be 0)
strcmp("abcdef", "", false, 2147483647): 1 (should be 1)
strcmp("", "abcdef", false, 2147483647): -1 (should be -1)
strcmp("abcdef", "", false, 0): 0 (should be 0)
strcmp("", "abcdef", false, 0): 0 (should be 0)
strcmp("abcdef", "abcdef", false, 2147483647): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 2147483647): 1 (should be 1)
strcmp("abcdef", "abcxyz", false, 2147483647): -1 (should be -1)
strcmp("abcdef", "abcdef", false, 0): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 0): 0 (should be 0)
strcmp("abcdef", "abcxyz", false, 0): 0 (should be 0)
strcmp("abcdef", "abcdef", false, 3): 0 (should be 0)
strcmp("abcxyz", "abcdef", false, 3): 0 (should be 0)
strcmp("abcdef", "abcxyz", false, 3): 0 (should be 0)
strcmp("abcdef", "abc", false, 2147483647): 1 (should be 1)
strcmp("abc", "abcdef", false, 2147483647): -1 (should be -1)
strcmp("abcdef", "abc", false, 5): 1 (should be 1)
strcmp("abc", "abcdef", false, 5): -1 (should be -1)
21/21 passed, 0/21 failed
```