### PR TITLE
Fixed "Stunt" textdraws' position and color

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -4121,11 +4121,11 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 13 (stunt).
-				t = FIXES_gsGTStyle[13] = TextDrawCreate(380.000000, 341.000000, FIXES_gsSpace),
-				TextDrawLetterSize(t, 0.579999, 2.400000),
+				t = FIXES_gsGTStyle[13] = TextDrawCreate(380.000000, 341.150000, FIXES_gsSpace),
+				TextDrawLetterSize(t, 0.579999, 2.420000),
 				TextDrawTextSize(t, 40.000000, 460.000000),
 				TextDrawAlignment(t, 2),
-				TextDrawColor(t, 0xD7D3CCFF),
+				TextDrawColor(t, 0xDDDDDBFF),
 				TextDrawUseBox(t, true),
 				TextDrawBoxColor(t, 0),
 				TextDrawSetShadow(t, 2),
@@ -4326,11 +4326,11 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 13 (playerid, stunt).
-				t = FIXES_gsPGTStyle[playerid][13] = CreatePlayerTextDraw(playerid, 380.000000, 341.000000, FIXES_gsSpace),
-				PlayerTextDrawLetterSize(playerid, t, 0.579999, 2.400000),
+				t = FIXES_gsPGTStyle[playerid][13] = CreatePlayerTextDraw(playerid, 380.000000, 341.150000, FIXES_gsSpace),
+				PlayerTextDrawLetterSize(playerid, t, 0.579999, 2.420000),
 				PlayerTextDrawTextSize(playerid, t, 40.000000, 460.000000),
 				PlayerTextDrawAlignment(playerid, t, 2),
-				PlayerTextDrawColor(playerid, t, 0xD7D3CCFF),
+				PlayerTextDrawColor(playerid, t, 0xDDDDDBFF),
 				PlayerTextDrawUseBox(playerid, t, true),
 				PlayerTextDrawBoxColor(playerid, t, 0),
 				PlayerTextDrawSetShadow(playerid, t, 2),


### PR DESCRIPTION
The same situation as in PR #59 but with "Stunt" textdraws.

Now you can see the difference between original screenshots of that gametext in singleplayer game, gametext that we have in 'fixes' before and after some fix (click on images to zoom in and to see a more detailed difference):

Original:
![gta_sa 2017-09-10 22-40-39-53](https://user-images.githubusercontent.com/13169094/30252563-7bc073f8-967d-11e7-840e-17b517a56002.jpg)

Textdraw in 'fixes' before:
![gta_sa 2017-09-10 22-45-19-32](https://user-images.githubusercontent.com/13169094/30252577-9ea87bae-967d-11e7-8bd6-fa4b68eb4bb1.jpg)

After position and color fix:
![gta_sa 2017-09-10 22-44-20-83](https://user-images.githubusercontent.com/13169094/30252581-abebe8f0-967d-11e7-9064-f597330c0d8e.jpg)