### PR TITLE
Fix for radio name textdraw size

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -5198,7 +5198,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 
 				// Global style 9 (radio name).
 				t = FIXES_gsGTStyle[9] = TextDrawCreate(320.000000, 22.000000, FIXES_gsSpace),
-				TextDrawLetterSize(t, 0.600000, 1.899999),
+				TextDrawLetterSize(t, 0.600000, 1.799999),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x906210FF),
 				TextDrawSetShadow(t, 0),
@@ -5212,7 +5212,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 
 				// Global style 10 (radio switch).
 				t = FIXES_gsGTStyle[10] = TextDrawCreate(320.000000, 22.000000, FIXES_gsSpace),
-				TextDrawLetterSize(t, 0.600000, 1.899999),
+				TextDrawLetterSize(t, 0.600000, 1.799999),
 				TextDrawAlignment(t, 2),
 				TextDrawColor(t, 0x969696FF),
 				TextDrawSetShadow(t, 0),
@@ -5403,7 +5403,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 
 				// Global style 9 (playerid, radio name).
 				t = FIXES_gsPGTStyle[playerid][9] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gsSpace),
-				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.899999),
+				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.799999),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x906210FF),
 				PlayerTextDrawSetShadow(playerid, t, 0),
@@ -5417,7 +5417,7 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 
 				// Global style 10 (playerid, radio switch).
 				t = FIXES_gsPGTStyle[playerid][10] = CreatePlayerTextDraw(playerid, 320.000000, 22.000000, FIXES_gsSpace),
-				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.899999),
+				PlayerTextDrawLetterSize(playerid, t, 0.600000, 1.799999),
 				PlayerTextDrawAlignment(playerid, t, 2),
 				PlayerTextDrawColor(playerid, t, 0x969696FF),
 				PlayerTextDrawSetShadow(playerid, t, 0),


### PR DESCRIPTION
Now you can see the difference between original screenshots of that gametext in singleplayer game, gametext that we have in 'fixes' before and after some fix (click on images to zoom in and to see a more detailed difference):

Original:
![gta_sa 2017-12-31 15-03-22-56](https://user-images.githubusercontent.com/13169094/34461560-5ce52802-ee3e-11e7-82e3-bc87d7491cf3.jpg)

Textdraw in 'fixes' before:
![gta_sa 2017-12-31 15-04-45-73](https://user-images.githubusercontent.com/13169094/34461562-63acce56-ee3e-11e7-9946-ec6c5163263b.jpg)

After size fix:
![gta_sa 2017-12-31 15-12-41-31](https://user-images.githubusercontent.com/13169094/34461563-688c86aa-ee3e-11e7-9df5-20de80eb0689.jpg)