### PR TITLE
Fixed shifting money textdraw

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -5356,29 +5356,29 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				TextDrawTextSize(t, 200.0, 620.0);
 
 				// Global style 11 (positive money).
-				t = FIXES_gsGTStyle[11] = TextDrawCreate(607.000000, 78.000000, FIXES_gsSpace),
-				TextDrawLetterSize(t, 0.550000, 2.150000),
+				t = FIXES_gsGTStyle[11] = TextDrawCreate(608.000000, 77.000000, FIXES_gsSpace),
+				TextDrawLetterSize(t, 0.550000, 2.200000),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0x36682CFF),
 				TextDrawSetShadow(t, 0),
 				TextDrawSetOutline(t, 2),
-				TextDrawBackgroundColor(t, 0x000000FF),
+				TextDrawBackgroundColor(t, 0x000000AA),
 				TextDrawFont(t, 3),
-				TextDrawSetProportional(t, 1),
+				TextDrawSetProportional(t, 0),
 				TextDrawUseBox(t, true),
 				TextDrawBoxColor(t, 0x00000000),
 				TextDrawTextSize(t, 10.0, 200.0);
 
 				// Global style 12 (negative money).
-				t = FIXES_gsGTStyle[12] = TextDrawCreate(607.000000, 78.000000, FIXES_gsSpace),
-				TextDrawLetterSize(t, 0.550000, 2.150000),
+				t = FIXES_gsGTStyle[12] = TextDrawCreate(608.000000, 77.000000, FIXES_gsSpace),
+				TextDrawLetterSize(t, 0.550000, 2.200000),
 				TextDrawAlignment(t, 3),
 				TextDrawColor(t, 0xB4191DFF),
 				TextDrawSetShadow(t, 0),
 				TextDrawSetOutline(t, 2),
-				TextDrawBackgroundColor(t, 0x000000FF),
+				TextDrawBackgroundColor(t, 0x000000AA),
 				TextDrawFont(t, 3),
-				TextDrawSetProportional(t, 1),
+				TextDrawSetProportional(t, 0),
 				TextDrawUseBox(t, true),
 				TextDrawBoxColor(t, 0x00000000),
 				TextDrawTextSize(t, 10.0, 200.0);
@@ -5561,29 +5561,29 @@ native BAD_IsPlayerConnected(playerid) = IsPlayerConnected;
 				PlayerTextDrawTextSize(playerid, t, 200.0, 620.0);
 
 				// Global style 11 (playerid, positive money).
-				t = FIXES_gsPGTStyle[playerid][11] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gsSpace),
-				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.150000),
+				t = FIXES_gsPGTStyle[playerid][11] = CreatePlayerTextDraw(playerid, 608.000000, 77.000000, FIXES_gsSpace),
+				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.200000),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0x36682CFF),
 				PlayerTextDrawSetShadow(playerid, t, 0),
 				PlayerTextDrawSetOutline(playerid, t, 2),
-				PlayerTextDrawBackgroundColor(playerid, t, 0x000000FF),
+				PlayerTextDrawBackgroundColor(playerid, t, 0x000000AA),
 				PlayerTextDrawFont(playerid, t, 3),
-				PlayerTextDrawSetProportional(playerid, t, 1),
+				PlayerTextDrawSetProportional(playerid, t, 0),
 				PlayerTextDrawUseBox(playerid, t, true),
 				PlayerTextDrawBoxColor(playerid, t, 0x00000000),
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);
 
 				// Global style 12 (playerid, negative money).
-				t = FIXES_gsPGTStyle[playerid][12] = CreatePlayerTextDraw(playerid, 607.000000, 78.000000, FIXES_gsSpace),
-				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.150000),
+				t = FIXES_gsPGTStyle[playerid][12] = CreatePlayerTextDraw(playerid, 608.000000, 77.000000, FIXES_gsSpace),
+				PlayerTextDrawLetterSize(playerid, t, 0.550000, 2.200000),
 				PlayerTextDrawAlignment(playerid, t, 3),
 				PlayerTextDrawColor(playerid, t, 0xB4191DFF),
 				PlayerTextDrawSetShadow(playerid, t, 0),
 				PlayerTextDrawSetOutline(playerid, t, 2),
-				PlayerTextDrawBackgroundColor(playerid, t, 0x000000FF),
+				PlayerTextDrawBackgroundColor(playerid, t, 0x000000AA),
 				PlayerTextDrawFont(playerid, t, 3),
-				PlayerTextDrawSetProportional(playerid, t, 1),
+				PlayerTextDrawSetProportional(playerid, t, 0),
 				PlayerTextDrawUseBox(playerid, t, true),
 				PlayerTextDrawBoxColor(playerid, t, 0x00000000),
 				PlayerTextDrawTextSize(playerid, t, 10.0, 200.0);


### PR DESCRIPTION
Finally I fixed the last case of shifting money (positive & negative) textdraw.
This problem is similar to #59, #72 and #83. See the screens below (click on each to enlarge and check the difference if needed).

Original:
![sa-mp-006](https://user-images.githubusercontent.com/13169094/51638349-2e4add80-1f6f-11e9-8bb0-5c2292d34b68.png)

Current textdraw in fixes (shifted):
![sa-mp-007](https://user-images.githubusercontent.com/13169094/51638395-4589cb00-1f6f-11e9-8939-9a44fcb63071.png)

Fixed:
![sa-mp-008](https://user-images.githubusercontent.com/13169094/51638410-4fabc980-1f6f-11e9-9154-c41d72f97c6c.png)
