### PR TITLE
Prevents loading twice if using 'y_rconfix'

### DIFF
--- a/fixes.inc
+++ b/fixes.inc
@@ -8440,7 +8440,10 @@ public OnGameModeInit()
 				}
 				if (fexist(FIXES_gscRconFixFS))
 				{
-					SendRconCommand__("loadfs ../scriptfiles/callbackfix");
+					#if defined _INC_y_rconfix
+						SendRconCommand__("loadfs ../scriptfiles/callbackfix");
+					#endif
+					
 					#if FIX_OnClientCheckResponse
 						state OnClientCheckResponse : OnClientCheckResponse_GM;
 					#endif


### PR DESCRIPTION
Fixes an error for those who use the YSI library