### PR TITLE
Add fixes for OnPlayerSpawn, OnPlayerKeyStateChange, OnPlayerStateChange

### DIFF
--- a/_fixes_options.inc
+++ b/_fixes_options.inc
@@ -345,6 +345,8 @@
 	#warning Option `FIX_OnPlayerSpawnCall` must now be explicit.
 #elseif _FIXES_WARNING == 146
 	#warning Option `FIX_OnPlayerStateChange` must now be explicit.
+#elseif _FIXES_WARNING == 147
+	#warning Option `FIX_OnPlayerKeyStateChange` must now be explicit.
 #else
 	#error `_fixes_options.inc` included, but `_FIXES_WARNING` is not set to a valid warning message.
 #endif

--- a/_fixes_options.inc
+++ b/_fixes_options.inc
@@ -343,6 +343,8 @@
 	#warning Option `FIX_SHA256` must now be explicit.
 #elseif _FIXES_WARNING == 145
 	#warning Option `FIX_OnPlayerSpawnCall` must now be explicit.
+#elseif _FIXES_WARNING == 146
+	#warning Option `FIX_OnPlayerStateChange` must now be explicit.
 #else
 	#error `_fixes_options.inc` included, but `_FIXES_WARNING` is not set to a valid warning message.
 #endif

--- a/_fixes_options.inc
+++ b/_fixes_options.inc
@@ -341,6 +341,8 @@
 	#warning Option `FIX_memcpy` must now be explicit.
 #elseif _FIXES_WARNING == 144
 	#warning Option `FIX_SHA256` must now be explicit.
+#elseif _FIXES_WARNING == 145
+	#warning Option `FIX_OnPlayerSpawnCall` must now be explicit.
 #else
 	#error `_fixes_options.inc` included, but `_FIXES_WARNING` is not set to a valid warning message.
 #endif

--- a/fixes.inc
+++ b/fixes.inc
@@ -7668,6 +7668,48 @@ _FIXES_FUNC_PAWNDOC(_FIXES_IS_UNSET(const symbol[]));
 	#define FIX_OnPlayerStateChange                  (0)
 #endif
 
+/**
+ * <library>fixes.inc</library>
+ * <fix name="OnPlayerStateChange">
+ *     <problem>
+ *         This function isn't called for players who are already in the server holding or pressing a key when a filterscript starts.
+ *         So this way it calls OnPlayerStateChange to make sure script never misses user action based code execution just key state
+ *         didn't change to call it yet.
+ *     </problem>
+ *     <solution>
+ *         Call it for all players.
+ *     </solution>
+ *     <see>On_FilterScriptInit</see>
+ *     <author    href="https://github.com/AmyrAhmady/" >iAmir</author>
+ * </fix>
+ */
+
+#if _FIXES_NPC
+	#if defined FIX_OnPlayerKeyStateChange
+		#undef FIX_OnPlayerKeyStateChange
+	#endif
+	static stock FIX_OnPlayerKeyStateChange = 0;
+	#define FIX_OnPlayerKeyStateChange                  (0)
+#elseif !defined FIX_OnPlayerKeyStateChange
+	#define _FIXES_WARNING 147
+	#tryinclude "_fixes_options"
+	#undef _FIXES_WARNING
+	static _FIXES_OPTION FIX_OnPlayerKeyStateChange = _FIXES_DEFAULT;
+	#define FIX_OnPlayerKeyStateChange                  _FIXES_DEFAULT
+#elseif _FIXES_IS_UNSET(FIX_OnPlayerKeyStateChange)
+	#undef FIX_OnPlayerKeyStateChange
+	static stock FIX_OnPlayerKeyStateChange = 2;
+	#define FIX_OnPlayerKeyStateChange                  (2)
+#elseif FIX_OnPlayerKeyStateChange
+	#undef FIX_OnPlayerKeyStateChange
+	static stock FIX_OnPlayerKeyStateChange = 1;
+	#define FIX_OnPlayerKeyStateChange                  (1)
+#else
+	#undef FIX_OnPlayerKeyStateChange
+	static stock FIX_OnPlayerKeyStateChange = 0;
+	#define FIX_OnPlayerKeyStateChange                  (0)
+#endif
+
 /*
 
     88b           d88
@@ -17533,6 +17575,24 @@ public OnJITCompile()
 						if (GetPlayerState__(playerid) != PLAYER_STATE_NONE)
 						{
 							CallLocalFunction("OnPlayerStateChange", "iii", playerid, GetPlayerState__(playerid), PLAYER_STATE_NONE);
+						}
+						// ========================
+						//  END:   OnPlayerStateChange
+						// ========================
+					#endif
+
+					// Just like above, if you don't have "OnPlayerKeyStateChange"
+					// script it's your fault! Just disable the fix!
+					#if FIX_OnPlayerKeyStateChange
+						// ========================
+						//  BEGIN: OnPlayerKeyStateChange
+						// ========================
+						// If key value is not 0, then let's call OnPlayerKeyStateChange
+						new KEY:keys, KEY:updown, KEY:leftright;
+						GetPlayerKeys__(playerid, keys, updown, leftright);
+						if (_:keys != 0)
+						{
+							OnPlayerKeyStateChange(playerid, keys, KEY:0);
 						}
 						// ========================
 						//  END:   OnPlayerStateChange

--- a/fixes.inc
+++ b/fixes.inc
@@ -7588,6 +7588,46 @@ _FIXES_FUNC_PAWNDOC(_FIXES_IS_UNSET(const symbol[]));
 	#define FIX_SHA256                           (0)
 #endif
 
+/**
+ * <library>fixes.inc</library>
+ * <fix name="OnPlayerSpawnCall">
+ *     <problem>
+ *         This function isn't called for players who are already spawned when a filterscript starts.
+ *     </problem>
+ *     <solution>
+ *         Call it for all spawned players.
+ *     </solution>
+ *     <see>On_FilterScriptInit</see>
+ *     <author    href="https://github.com/AmyrAhmady/" >iAmir</author>
+ * </fix>
+ */
+
+#if _FIXES_NPC
+	#if defined FIX_OnPlayerSpawnCall
+		#undef FIX_OnPlayerSpawnCall
+	#endif
+	static stock FIX_OnPlayerSpawnCall = 0;
+	#define FIX_OnPlayerSpawnCall                  (0)
+#elseif !defined FIX_OnPlayerSpawnCall
+	#define _FIXES_WARNING 145
+	#tryinclude "_fixes_options"
+	#undef _FIXES_WARNING
+	static _FIXES_OPTION FIX_OnPlayerSpawnCall = _FIXES_DEFAULT;
+	#define FIX_OnPlayerSpawnCall                  _FIXES_DEFAULT
+#elseif _FIXES_IS_UNSET(FIX_OnPlayerSpawnCall)
+	#undef FIX_OnPlayerSpawnCall
+	static stock FIX_OnPlayerSpawnCall = 2;
+	#define FIX_OnPlayerSpawnCall                  (2)
+#elseif FIX_OnPlayerSpawnCall
+	#undef FIX_OnPlayerSpawnCall
+	static stock FIX_OnPlayerSpawnCall = 1;
+	#define FIX_OnPlayerSpawnCall                  (1)
+#else
+	#undef FIX_OnPlayerSpawnCall
+	static stock FIX_OnPlayerSpawnCall = 0;
+	#define FIX_OnPlayerSpawnCall                  (0)
+#endif
+
 /*
 
     88b           d88
@@ -17422,6 +17462,25 @@ public OnJITCompile()
 							//  END:   GameText
 							// =================
 						#endif
+					#endif
+
+					// Just like above with "OnPlayerConnect", if you don't have 
+					// "OnPlayerSpawn" script it's your fault! Just disable the fix!
+					#if FIX_OnPlayerSpawnCall
+						// ========================
+						//  BEGIN: OnPlayerSpawn
+						// ========================
+						// If it's any state other than the ones below, it means player
+						// has surely been spawned once, so let's call it because then how
+						// would filterscript process that and user's code related to spawn
+						// get executed?
+						if (GetPlayerState__(playerid) != PLAYER_STATE_WASTED && GetPlayerState__(playerid) != PLAYER_STATE_NONE && GetPlayerState__(playerid) != PLAYER_STATE_SPECTATING)
+						{
+							OnPlayerSpawn(playerid);
+						}
+						// ========================
+						//  END:   OnPlayerSpawn
+						// ========================
 					#endif
 				}
 			}

--- a/fixes.inc
+++ b/fixes.inc
@@ -7628,6 +7628,46 @@ _FIXES_FUNC_PAWNDOC(_FIXES_IS_UNSET(const symbol[]));
 	#define FIX_OnPlayerSpawnCall                  (0)
 #endif
 
+/**
+ * <library>fixes.inc</library>
+ * <fix name="OnPlayerStateChange">
+ *     <problem>
+ *         This function isn't called for players who are already in the server with state when a filterscript starts.
+ *     </problem>
+ *     <solution>
+ *         Call it for all players.
+ *     </solution>
+ *     <see>On_FilterScriptInit</see>
+ *     <author    href="https://github.com/AmyrAhmady/" >iAmir</author>
+ * </fix>
+ */
+
+#if _FIXES_NPC
+	#if defined FIX_OnPlayerStateChange
+		#undef FIX_OnPlayerStateChange
+	#endif
+	static stock FIX_OnPlayerStateChange = 0;
+	#define FIX_OnPlayerStateChange                  (0)
+#elseif !defined FIX_OnPlayerStateChange
+	#define _FIXES_WARNING 146
+	#tryinclude "_fixes_options"
+	#undef _FIXES_WARNING
+	static _FIXES_OPTION FIX_OnPlayerStateChange = _FIXES_DEFAULT;
+	#define FIX_OnPlayerStateChange                  _FIXES_DEFAULT
+#elseif _FIXES_IS_UNSET(FIX_OnPlayerStateChange)
+	#undef FIX_OnPlayerStateChange
+	static stock FIX_OnPlayerStateChange = 2;
+	#define FIX_OnPlayerStateChange                  (2)
+#elseif FIX_OnPlayerStateChange
+	#undef FIX_OnPlayerStateChange
+	static stock FIX_OnPlayerStateChange = 1;
+	#define FIX_OnPlayerStateChange                  (1)
+#else
+	#undef FIX_OnPlayerStateChange
+	static stock FIX_OnPlayerStateChange = 0;
+	#define FIX_OnPlayerStateChange                  (0)
+#endif
+
 /*
 
     88b           d88
@@ -17464,11 +17504,11 @@ public OnJITCompile()
 						#endif
 					#endif
 
-					// Just like above with "OnPlayerConnect", if you don't have 
-					// "OnPlayerSpawn" script it's your fault! Just disable the fix!
+					// Just like above, if you don't have "OnPlayerSpawn"
+					// script it's your fault! Just disable the fix!
 					#if FIX_OnPlayerSpawnCall
 						// ========================
-						//  BEGIN: OnPlayerSpawn
+						//  BEGIN: OnPlayerSpawnCall
 						// ========================
 						// If it's any state other than the ones below, it means player
 						// has surely been spawned once, so let's call it because then how
@@ -17479,7 +17519,23 @@ public OnJITCompile()
 							OnPlayerSpawn(playerid);
 						}
 						// ========================
-						//  END:   OnPlayerSpawn
+						//  END:   OnPlayerSpawnCall
+						// ========================
+					#endif
+
+					// This time since we don't have any "OnPlayerStateChange" defined
+					// we use "CallLocalFunction" for it
+					#if FIX_OnPlayerStateChange
+						// ========================
+						//  BEGIN: OnPlayerStateChange
+						// ========================
+						// If state is not "none", then let's call OnPlayerStateChange
+						if (GetPlayerState__(playerid) != PLAYER_STATE_NONE)
+						{
+							CallLocalFunction("OnPlayerStateChange", "iii", playerid, GetPlayerState__(playerid), PLAYER_STATE_NONE);
+						}
+						// ========================
+						//  END:   OnPlayerStateChange
 						// ========================
 					#endif
 				}


### PR DESCRIPTION
This amazing PR adds three new fixes to one of the most used libraries of SA-MP community.

### 1. OnPlayerSpawn
I noticed while `OnPlayerConnect` is called when a filterscript loads, fixes.inc doesn't call `OnPlayerSpawn` for all spawned players. So imagine this situation: What if players are already spawned and user is doing some sort of initialization like some sort of cheat detection or something, and when script is loaded mid-game, that type of code never runs for players who are already spawned! This is such an important and required fix!
Also this fix internally is called `FIX_OnPlayerSpawnCall` since `FIX_OnPlayerSpawn` is taken. But I guess it shouldn't be a problem, if it is, let me know, I offer to quickly modify it based on your preferences.
 
### 2. OnPlayerKeyStateChange
Just like `OnPlayerSpawn` but this time for keys. What if a player is already holding a key and you load your filterscript? Then script's `OnPlayerKeyStateChange` would never get called, because there's no change yet! You may ask well why even call it then since there's no change? That's because players are already connected so why are you calling OnPlayerConnect? To fix it!

### 3. OnPlayerStateChange
This works just like both above, I need my filterscript to be aware when it's loaded and there are players in different states



## Note:
This is my first time contributing to fixes.inc project, if there's any problem in my code and it goes against fixes.inc guidelines, let me know because I'm offering to fix my own mistakes for free. Thanks!
